### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,10 @@
 ---
 name: Build and Push multi-arch Docker image
 
+permissions:
+  contents: read
+  packages: write
+
 on:
   release:
     types:


### PR DESCRIPTION
Potential fix for [https://github.com/docker-client/echo-server/security/code-scanning/3](https://github.com/docker-client/echo-server/security/code-scanning/3)

To fix the issue, we will add a `permissions` block to the root of the workflow file. This block will define the minimal permissions required for the workflow to function correctly. Based on the actions used in the workflow (e.g., `actions/checkout`, `docker/login-action`, `docker/build-push-action`), the workflow primarily requires `contents: read` for accessing the repository and `packages: write` for pushing Docker images. We will apply these permissions globally to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
